### PR TITLE
Implement toString nicely

### DIFF
--- a/lib/receive_intent.dart
+++ b/lib/receive_intent.dart
@@ -54,6 +54,13 @@ class Intent {
         "categories": categories,
         "extra": extra,
       };
+
+  @override
+  String toString() {
+    if (isNull) return 'Intent(null)';
+    var str = 'Intent${toMap()}';
+    return str.replaceFirst('{', '(').replaceFirst('}', ')', str.length - 1);
+  }
 }
 
 class ReceiveIntent {


### PR DESCRIPTION
I added nice `toString` method - now you can, for example:
```dart
ReceiveIntent.getInitialIntent().then(print);
ReceiveIntent.receiveIntentStream.listen(print);
```

By the way - you can add a `hacktoberfest` tag to your repo to participate in Hacktoberfest (people (me for example) getting t-shirts :wink: )