### PR TITLE
Allow receipt of intents with no action

### DIFF
--- a/lib/receive_intent.dart
+++ b/lib/receive_intent.dart
@@ -10,7 +10,7 @@ class Intent {
   final bool isNull;
   final String? fromPackageName;
   final List<String>? fromSignatures;
-  final String action;
+  final String? action;
   final String? data;
   final List<String>? categories;
   final Map<String, dynamic>? extra;
@@ -21,7 +21,7 @@ class Intent {
     this.isNull = true,
     this.fromPackageName,
     this.fromSignatures,
-    required this.action,
+    this.action,
     this.data,
     this.categories,
     this.extra,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: receive_intent
 description: Flutter plugin for passing Android Intents to the Flutter environment.
-version: 0.1.6
+version: 0.2.0
 homepage: https://github.com/daadu/receive_intent
 
 environment:


### PR DESCRIPTION
Not all Intents have an action so this change allows us to receive those.

One example is the intents Android generates from the Autofill service.