### PR TITLE
feat: add namespace directive for gradle 8.0 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.5.31'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -17,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.bhikadia.receive_intent'
     compileSdkVersion 30
 
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,9 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    namespace 'com.bhikadia.receive_intent'
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.bhikadia.receive_intent'
+    }
     compileSdkVersion 30
 
     sourceSets {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,9 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    namespace "com.bhikadia.receive_intent_example"
+    if (project.android.hasProperty("namespace")) {
+        namespace "com.bhikadia.receive_intent_example"
+    }
     compileSdkVersion 30
 
     sourceSets {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "com.bhikadia.receive_intent_example"
     compileSdkVersion 30
 
     sourceSets {


### PR DESCRIPTION
Using gradle 8.0 fails unless there is a namespace directive in the build.gradle file.  This will allow project that use this library to use gradle >= 8.0.