### PR TITLE
fix(android): compile to Android SDK 35

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ android {
         namespace 'com.bhikadia.receive_intent'
     }
 
-    compileSdk 34
+    compileSdk 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/src/main/kotlin/com/bhikadia/receive_intent/Utils.kt
+++ b/android/src/main/kotlin/com/bhikadia/receive_intent/Utils.kt
@@ -158,6 +158,7 @@ fun getApplicationSignature(context: Context, packageName: String): List<String>
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             // New signature
             val sig = context.packageManager.getPackageInfo(packageName, PackageManager.GET_SIGNING_CERTIFICATES).signingInfo
+                ?: throw IllegalStateException("no signature found")
             signatureList = if (sig.hasMultipleSigners()) {
                 // Send all with apkContentsSigners
                 sig.apkContentsSigners.map {
@@ -175,6 +176,7 @@ fun getApplicationSignature(context: Context, packageName: String): List<String>
             }
         } else {
             val sig = context.packageManager.getPackageInfo(packageName, PackageManager.GET_SIGNATURES).signatures
+                ?: throw IllegalStateException("no signature found")
             signatureList = sig.map {
                 val digest = MessageDigest.getInstance("SHA-256")
                 digest.update(it.toByteArray())


### PR DESCRIPTION
Hello there,

I had issues migrating to android sdk 35 and had to fork this lib to do the following commit.

I had to change the source code too because there were a compile error otherwise. Since the code block has a try/catch, i propose to simply throw an `IllegalStateException` if no signatures is found. It is a simple fix I did to go forward with my dev, but I didn't really consider the impact. Please, feel free to tell me if we should do something else.

Best Regards.

~MoovBuilder983