### PR TITLE
Differentiate between multiple intents with the same action and category

### DIFF
--- a/android/src/main/kotlin/com/bhikadia/receive_intent/ReceiveIntentPlugin.kt
+++ b/android/src/main/kotlin/com/bhikadia/receive_intent/ReceiveIntentPlugin.kt
@@ -41,6 +41,7 @@ class ReceiveIntentPlugin : FlutterPlugin, MethodCallHandler, EventChannel.Strea
         // Log.e("ReceiveIntentPlugin", "decodeData: $decodeData")
         // Log.e("ReceiveIntentPlugin", "fromPackageName: $fromPackageName")
         val intentMap = mapOf<String, Any?>(
+                "componentClassName" to intent.component?.className,
                 "fromPackageName" to fromPackageName,
                 "fromSignatures" to fromPackageName?.let { getApplicationSignature(context, it) },
                 "action" to intent.action,

--- a/lib/receive_intent.dart
+++ b/lib/receive_intent.dart
@@ -17,6 +17,7 @@ const kActivityResultCanceled = 0;
 
 class Intent {
   final bool isNull;
+  final String? componentClassName;
   final String? fromPackageName;
   final List<String>? fromSignatures;
   final String? action;
@@ -28,6 +29,7 @@ class Intent {
 
   const Intent({
     this.isNull = true,
+    this.componentClassName,
     this.fromPackageName,
     this.fromSignatures,
     this.action,
@@ -38,6 +40,7 @@ class Intent {
 
   factory Intent.fromMap(Map? map) => Intent(
         isNull: map == null,
+    componentClassName: map?["componentClassName"],
         fromPackageName: map?["fromPackageName"],
         fromSignatures: map?["fromSignatures"] != null
             ? List.unmodifiable(


### PR DESCRIPTION
This PR solves the issue of differentiating between multiple intents with the same action and category.
- Passes component class name as part of the intent object

Example:
- an app might have multiple activity aliases that link to different parts of the application
- all of them accept plain text input or URLs
- For these actions to appear in the Android share dialog as separate items, all of them has to use `android.intent.action.SEND`
- To differentiate on the Flutter side between these intents you need a field that differs
- Action will be identical, while category fields will be typically stripped
- Component class name is a reliable way to differentiate between these intents

Example manifest:
```
...
 <activity-alias
            android:name=".AssistantAlias"
            android:exported="true"
            android:label="@string/share_intent_label_assistant"
            android:targetActivity=".MainActivity">
            <intent-filter android:label="@string/share_intent_label_assistant">
                <action android:name="android.intent.action.SEND" />
                <category android:name="android.intent.category.DEFAULT" />
                <data android:mimeType="text/*" />
                <data android:mimeType="image/*" />
                <data android:mimeType="application/pdf" />
            </intent-filter>
        </activity-alias>
        <activity-alias
            android:name=".SummarizeAlias"
            android:exported="true"
            android:label="@string/share_intent_label_summarize"
            android:targetActivity=".MainActivity">
            <intent-filter android:label="@string/share_intent_label_summarize">
                <action android:name="android.intent.action.SEND" />
                <category android:name="android.intent.category.DEFAULT" />
                <data android:mimeType="text/plain" />
            </intent-filter>
        </activity-alias>
        <activity-alias
            android:name=".TranslateAlias"
            android:exported="true"
            android:label="@string/share_intent_label_translate"
            android:targetActivity=".MainActivity">
            <intent-filter android:label="@string/share_intent_label_translate">
                <action android:name="android.intent.action.SEND" />
                <category android:name="android.intent.category.DEFAULT" />
                <data android:mimeType="text/plain" />
            </intent-filter>
        </activity-alias>
...
```

Alternative solutions are to pass meta-data or other custom fields from the android intent to Flutter, but I didn't have any success using these.